### PR TITLE
Added new referral urls

### DIFF
--- a/scripts/update-data.ts
+++ b/scripts/update-data.ts
@@ -9,7 +9,7 @@ const DATA_FILE = path.join(
   new URL(".", import.meta.url).pathname,
   "..",
   "src",
-  "data.ts"
+  "data.ts",
 );
 
 (async () => {
@@ -22,10 +22,10 @@ const DATA_FILE = path.join(
     ).json();
 
     const protocolsMap = new Map<string, Record<string, string>>(
-      resProtocols.map((x: Record<string, string>) => [x.slug, x])
+      resProtocols.map((x: Record<string, string>) => [x.slug, x]),
     );
     const chainsMap = new Map<string, Record<string, string>>(
-      resChains.map((x: Record<string, string>) => [x.name, x])
+      resChains.map((x: Record<string, string>) => [x.name, x]),
     );
 
     const updatedProtocols = await Promise.all(
@@ -47,7 +47,7 @@ const DATA_FILE = path.join(
             await fetch("https://api.coingecko.com/api/v3/asset_platforms")
           ).json();
           const match = res.find(
-            (p: any) => p.native_coin_id === llama.gecko_id
+            (p: any) => p.native_coin_id === llama.gecko_id,
           );
 
           logo = match?.image?.thumb || null;
@@ -69,7 +69,7 @@ const DATA_FILE = path.join(
             url: defillama.url || llama.url!,
           },
         };
-      })
+      }),
     );
 
     const file = `import type { Protocol } from "./types.ts";

--- a/src/data.ts
+++ b/src/data.ts
@@ -596,7 +596,7 @@ const protocols: Protocol[] = [
         "USDhl is a fiat stable custom-built for the Hyperliquid ecosystem, serving as a building block for HIP-3, fx, payments, and more",
       logo: "https://icons.llama.fi/felix-usdhl.jpg",
       twitter: "usd_hl",
-      url: "https://www.usefelix.xyz?ref=4BF702FF",
+      url: "https://www.usefelix.xyz",
     },
   },
 ];

--- a/src/data.ts
+++ b/src/data.ts
@@ -274,7 +274,8 @@ const protocols: Protocol[] = [
     name: "Swaps.io",
     listedAt: 1741711269,
     portfolioUrl: "https://swaps.io/",
-    referralUrl:"https://swaps.io/referral/0xd3be243c7b11cc0233af0caebac54b713d1403b1?f=668467",
+    referralUrl:
+      "https://swaps.io/referral/0xd3be243c7b11cc0233af0caebac54b713d1403b1?f=668467",
     module: "adapters/swapsio.ts",
     defillama: {
       slug: "",
@@ -543,7 +544,7 @@ const protocols: Protocol[] = [
     listedAt: 1761777901,
     module: "adapters/hyperflow.ts",
     portfolioUrl: "https://hyperflow.fun/points",
-    referralUrl:"https://hyperflow.fun?ref=A3GGq",
+    referralUrl: "https://hyperflow.fun?ref=A3GGq",
     defillama: {
       slug: "hyperflow",
       description:
@@ -591,12 +592,13 @@ const protocols: Protocol[] = [
     portfolioUrl: "https://www.usefelix.xyz/points",
     defillama: {
       slug: "felix-usdhl",
-      description: "USDhl is a fiat stable custom-built for the Hyperliquid ecosystem, serving as a building block for HIP-3, fx, payments, and more",
+      description:
+        "USDhl is a fiat stable custom-built for the Hyperliquid ecosystem, serving as a building block for HIP-3, fx, payments, and more",
       logo: "https://icons.llama.fi/felix-usdhl.jpg",
       twitter: "usd_hl",
-      url: "https://www.usefelix.xyz?ref=4BF702FF"
-    }
-  }
+      url: "https://www.usefelix.xyz?ref=4BF702FF",
+    },
+  },
 ];
 
 export default protocols;

--- a/src/data.ts
+++ b/src/data.ts
@@ -5,7 +5,7 @@ const protocols: Protocol[] = [
     id: 1,
     name: "Avalon Finance",
     listedAt: 1741711269,
-    portfolioUrl: "https://app.avalonfinance.xyz/points",
+    portfolioUrl: "https://app.avalonfinance.xyz/rewards",
     module: "adapters/avalon.ts",
     defillama: {
       slug: "avalon-finance",
@@ -274,6 +274,7 @@ const protocols: Protocol[] = [
     name: "Swaps.io",
     listedAt: 1741711269,
     portfolioUrl: "https://swaps.io/",
+    referralUrl:"https://swaps.io/referral/0xd3be243c7b11cc0233af0caebac54b713d1403b1?f=668467",
     module: "adapters/swapsio.ts",
     defillama: {
       slug: "",
@@ -353,7 +354,7 @@ const protocols: Protocol[] = [
     name: "Syrup",
     listedAt: 1743179811,
     module: "adapters/syrup.ts",
-    portfolioUrl: "https://syrup.fi/portfolio",
+    portfolioUrl: "https://app.maple.finance/earn/portfolio",
     defillama: {
       slug: "",
       description: "Institutional yield, unlocked.",
@@ -542,6 +543,7 @@ const protocols: Protocol[] = [
     listedAt: 1761777901,
     module: "adapters/hyperflow.ts",
     portfolioUrl: "https://hyperflow.fun/points",
+    referralUrl:"https://hyperflow.fun?ref=A3GGq",
     defillama: {
       slug: "hyperflow",
       description:

--- a/src/data.ts
+++ b/src/data.ts
@@ -177,6 +177,8 @@ const protocols: Protocol[] = [
     listedAt: 1741711269,
     portfolioUrl: "https://app.methprotocol.xyz/campaigns/methamorphosis-s3",
     module: "adapters/methprotocol.ts",
+    referralUrl:
+      "https://app.methprotocol.xyz/campaigns/methamorphosis-s3/c1eM098z08",
     defillama: {
       slug: "meth-protocol",
       description:
@@ -274,8 +276,6 @@ const protocols: Protocol[] = [
     name: "Swaps.io",
     listedAt: 1741711269,
     portfolioUrl: "https://swaps.io/",
-    referralUrl:
-      "https://swaps.io/referral/0xd3be243c7b11cc0233af0caebac54b713d1403b1?f=668467",
     module: "adapters/swapsio.ts",
     defillama: {
       slug: "",
@@ -402,6 +402,7 @@ const protocols: Protocol[] = [
     listedAt: 1743287542,
     module: "adapters/ethereal.ts",
     portfolioUrl: "https://deposit.ethereal.trade/points",
+    referralUrl: "https://deposit.ethereal.trade/waitlist?ref=OAE517",
     defillama: {
       slug: "ethereal-season-zero",
       description:
@@ -591,13 +592,14 @@ const protocols: Protocol[] = [
     listedAt: 1762470838,
     module: "adapters/felix.ts",
     portfolioUrl: "https://www.usefelix.xyz/points",
+    referralUrl: "https://www.usefelix.xyz?ref=4BF702FF",
     defillama: {
       slug: "felix-usdhl",
       description:
         "USDhl is a fiat stable custom-built for the Hyperliquid ecosystem, serving as a building block for HIP-3, fx, payments, and more",
       logo: "https://icons.llama.fi/felix-usdhl.jpg",
       twitter: "usd_hl",
-      url: "https://www.usefelix.xyz?ref=4BF702FF",
+      url: "https://www.usefelix.xyz",
     },
   },
 ];

--- a/src/data.ts
+++ b/src/data.ts
@@ -592,7 +592,6 @@ const protocols: Protocol[] = [
     listedAt: 1762470838,
     module: "adapters/felix.ts",
     portfolioUrl: "https://www.usefelix.xyz/points",
-    referralUrl: "https://www.usefelix.xyz?ref=4BF702FF",
     defillama: {
       slug: "felix-usdhl",
       description:


### PR DESCRIPTION
- Added two new referral program URLs to protocols that are supported

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated portfolio endpoint URLs for Avalon Finance and Syrup to point to their current portfolio/rewards pages.
  * Added or updated public referral links for Meth Protocol, Ethereal, Hyperflow, and Felix; adjusted Felix URL to canonical form.
  * Performed minor formatting and configuration refinements to protocol data entries (no functional behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->