### PR TITLE
Added claim link to infrared finance

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -465,6 +465,7 @@ const protocols: Protocol[] = [
     listedAt: 1745509142,
     module: "adapters/infrared.ts",
     portfolioUrl: "https://infrared.finance/points",
+    claimUrl: "https://infrared.finance/points",
     defillama: {
       slug: "infrared-finance",
       description:


### PR DESCRIPTION
Claim link has been added to infrared finance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a claims URL link for the Infrared Finance protocol, enabling users to conveniently access protocol claiming functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->