### PR TITLE
Adding rips, leaderboard and betrmint to data

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -726,6 +726,51 @@ const protocols: Protocol[] = [
       url: "https://www.aroundtheworld.fun/",
     },
   },
+  {
+    id: 47,
+    name: "Rips",
+    listedAt: 1768772485,
+    module: "adapters/rip.ts",
+    portfolioUrl: "https://rips.app/",
+    defillama: {
+      slug: "",
+      description:
+        "Ripsapp, a pack-opening token discovery mini-app built on the Base blockchain where users rip curated packs to pull mystery ERC-20 coins. ",
+      logo: "https://wrpcd.net/cdn-cgi/imagedelivery/BXluQx4ige9GuW0Ia56BHw/a6861c5b-59b4-467a-cc92-a8453948ec00/anim=false,fit=contain,f=auto,w=auto",
+      twitter: "ripsapp",
+      url: "https://rips.app/",
+    },
+  },
+  {
+    id: 48,
+    name: "The Leaderboard",
+    listedAt: 1768772485,
+    module: "adapters/theleaderboard.ts",
+    portfolioUrl:
+      "https://farcaster.xyz/miniapps/0195fc74-6cde-b71e-df43-98e0d6768e32/the-leaderboard",
+    defillama: {
+      slug: "",
+      description: "Earn points, flex your rank, and maybe, earn rewards",
+      logo: "https://proxy.wrpcd.net/?url=https%3A%2F%2Fleaderboard.frm.lol%2Fimages%2Fleaderboard.png&s=068f06dafc87f9c7671728268234c5c6ee829c33f5bf8990108248801877ff2c",
+      twitter: "",
+      url: "https://farcaster.xyz/miniapps/0195fc74-6cde-b71e-df43-98e0d6768e32/the-leaderboard",
+    },
+  },
+  {
+    id: 49,
+    name: "Betrmint",
+    listedAt: 1768772485,
+    module: "adapters/btrmint.ts",
+    portfolioUrl: "https://farcaster.xyz/miniapps/yG210D-5eNqL/betrmint",
+    defillama: {
+      slug: "",
+      description:
+        "BETRMINT, a mint-to-spin mini-app on Base where users mint creator editions to earn free spins on the Neon Flywheel for $BETR and partner token rewards.",
+      logo: "https://wrpcd.net/cdn-cgi/imagedelivery/BXluQx4ige9GuW0Ia56BHw/0a162730-c586-46f6-5517-da0013a90a00/anim=false,fit=contain,f=auto,w=90",
+      twitter: "",
+      url: "https://farcaster.xyz/miniapps/yG210D-5eNqL/betrmint",
+    },
+  },
 ];
 
 export default protocols;


### PR DESCRIPTION
- Adding data for rips, betrmint and the leaderboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new protocols: Rips, The Leaderboard, and Betrmint. Each protocol includes portfolio tracking integration and DeFiLlama metadata support with associated branding assets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->