### PR TITLE
Add IntegraLayer protocol

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -950,6 +950,21 @@ const protocols: Protocol[] = [
       url: "https://megaeth.com/",
     },
   },
+  {
+    id: 61,
+    name: "IntegraLayer",
+    listedAt: 1777529700,
+    module: "adapters/integralayer.ts",
+    portfolioUrl: "https://dashboard.integralayer.com/stats",
+    defillama: {
+      slug: "",
+      description:
+        "IntegraLayer is building AI and blockchain infrastructure for real estate, bringing asset passports, agent identity, and global real estate liquidity onchain.",
+      logo: "https://checkpoint.exchange/logos/integralayer-logo.svg",
+      twitter: "integra_layer",
+      url: "https://integralayer.com/",
+    },
+  },
 ];
 
 export default protocols;


### PR DESCRIPTION
## Summary
- Add IntegraLayer to the protocol catalog.
- Point the protocol entry at the local Checkpoint logo asset and IntegraLayer stats dashboard.

## Test plan
- Verified metadata points to the existing public `integralayer-logo.svg` asset.
- Not run: catalog-specific automated tests were not available for this submodule.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IntegraLayer protocol support to the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->